### PR TITLE
Fixed a bug where BeatSaber UI collapses when PlayButton's gameObject is null.

### DIFF
--- a/ConfirmPlaylistDifficulty/Configuration/PluginConfig.cs
+++ b/ConfirmPlaylistDifficulty/Configuration/PluginConfig.cs
@@ -1,5 +1,5 @@
-﻿using IPA.Config.Stores;
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
+using IPA.Config.Stores;
 
 [assembly: InternalsVisibleTo(GeneratedStore.AssemblyVisibilityTarget)]
 namespace ConfirmPlaylistDifficulty.Configuration
@@ -11,20 +11,22 @@ namespace ConfirmPlaylistDifficulty.Configuration
         private bool enable = true;
         public virtual bool Enable
         {
-            get { return enable; }
+            get => this.enable;
             set
             {
-                // DataModel.defaultColor != nullやDataModel._actionButton != nullとなることはないはずだけど一応
-                if (value == false && DataModel.defaultColor != null && DataModel._actionButton != null)
+                if (this.enable != value)
                 {
-                    DataModel.ChangeStartButtonColor(false);
-                }
-                else if (value == true && DataModel.defaultColor != null && DataModel._actionButton != null)
-                {
-                    DataModel.RefreshButtonColor();
+                    this.enable = value;
+                    if (value)
+                    {
+                        DataModel.RefreshButtonColor();
+                    }
+                    else
+                    {
+                        DataModel.ChangeStartButtonColor(toWarningColor: false);
+                    }
                 }
 
-                enable = value;
             }
         }
     }

--- a/ConfirmPlaylistDifficulty/DataModel.cs
+++ b/ConfirmPlaylistDifficulty/DataModel.cs
@@ -1,4 +1,5 @@
-﻿using BeatSaberPlaylistsLib.Types;
+﻿using System.Linq;
+using BeatSaberPlaylistsLib.Types;
 using HMUI;
 using IPA.Utilities;
 using UnityEngine;
@@ -11,63 +12,59 @@ namespace ConfirmPlaylistDifficulty
         internal static Color defaultColor;
         internal static Button _actionButton;
         internal static IDifficultyBeatmap difficultyBeatmap;
-        internal static SongDetailsCache.Structs.MapCharacteristic characteristic;
         internal static IPlaylistSong playlistSong = null;
+        internal static SelectLevelCategoryViewController.LevelCategory selectedLevelCategory;
 
         public static void RefreshButtonColor()
         {
-            // playlistSongのキャッシュがある場合
-            if (DataModel.playlistSong != null && DataModel.difficultyBeatmap != null && DataModel.characteristic != null)
-            {
-                if (DataModel.playlistSong.levelID == DataModel.difficultyBeatmap.level.levelID)
-                {
-                    // プレイリストの難易度指定が無い場合
-                    if (DataModel.playlistSong.Difficulties == null)
-                    {
-                        ChangeStartButtonColor(false);
-                        return;
-                    }
-                    // プレイリストの難易度指定がある場合
-                    else
-                    {
-                        foreach (var difficulty in DataModel.playlistSong.Difficulties)
-                        {
-                            // プレイリストの難易度を選択している場合
-                            if (difficulty.Characteristic == DataModel.characteristic.ToString()
-                                && difficulty.BeatmapDifficulty == DataModel.difficultyBeatmap.difficulty)
-                            {
-                                ChangeStartButtonColor(false);
-                                return;
-                            }
-                        }
+            var isTargetLevelSelected = playlistSong?.levelID == difficultyBeatmap?.level?.levelID;
 
-                        // プレイリストの難易度を選択していない場合
-                        ChangeStartButtonColor(true);
-                        return;
-                    }
-                }
+            // プレイリストの難易度を選択していれば true
+            var selectedCharasteristic = difficultyBeatmap?.parentDifficultyBeatmapSet?.beatmapCharacteristic?.serializedName;
 
-                ChangeStartButtonColor(false);
-            }
+            var isTargetDifficultySelected =
+                selectedCharasteristic != null &&
+                playlistSong
+                    ?.Difficulties
+                    ?.Any(x => x.Characteristic == selectedCharasteristic && x.BeatmapDifficulty == difficultyBeatmap?.difficulty)
+                    == true;
+
+            var shouldWarn = isTargetLevelSelected && !isTargetDifficultySelected;
+            ChangeStartButtonColor(toWarningColor: shouldWarn);
         }
 
-        public static void ChangeStartButtonColor(bool red)
+        public static void ChangeStartButtonColor(bool toWarningColor)
         {
-            foreach (var bg in DataModel._actionButton.GetComponentsInChildren<ImageView>())
+            if (DataModel._actionButton?.IsDestroyed() != false)
             {
-                if (bg.name == "BG")
-                {
-                    if (red)
-                    {
-                        bg.color = Color.red;
-                        bg.SetField("_gradient", false);
-                    }
-                    else
-                    {
-                        bg.color = DataModel.defaultColor;
-                        bg.SetField("_gradient", true);
-                    }
-                }
+                Plugin.Log.Warn($"Action button is destroyed. Skipping start button color change.");
+                return;
+            }
+
+            if (DataModel._actionButton.gameObject == null)
+            {
+                Plugin.Log.Warn($"DataModel._actionButton is null. Skipping start button color change.");
+                return;
+            }
+
+            var bg = DataModel._actionButton.GetComponentsInChildren<ImageView>()
+                ?.SingleOrDefault(x => x.name == "BG");
+
+            if (bg == null)
+            {
+                Plugin.Log.Warn("Failed to find BG ImageView.");
+                return;
+            }
+
+            if (toWarningColor)
+            {
+                bg.color = Color.red;
+                bg.SetField("_gradient", false);
+            }
+            else
+            {
+                bg.color = DataModel.defaultColor;
+                bg.SetField("_gradient", true);
             }
         }
     }

--- a/ConfirmPlaylistDifficulty/HarmonyPatches/Patches.cs
+++ b/ConfirmPlaylistDifficulty/HarmonyPatches/Patches.cs
@@ -1,9 +1,7 @@
-﻿using ConfirmPlaylistDifficulty.Configuration;
+﻿using System.Linq;
+using ConfirmPlaylistDifficulty.Configuration;
 using HarmonyLib;
 using HMUI;
-using IPA.Utilities;
-using System;
-using System.Linq;
 using UnityEngine;
 
 /// <summary>
@@ -24,46 +22,35 @@ namespace ConfirmPlaylistDifficulty.HarmonyPatches
         /// <param name="arg1">The Parameter1Type arg1 that was passed to MethodToPatch</param>
         /// <param name="____privateFieldInClassToPatch">Reference to the private field in ClassToPatch named '_privateFieldInClassToPatch', 
         ///     added three _ to the beginning to reference it in the patch. Adding ref means we can change it.</param>
-        static void Postfix(IBeatmapLevel ____level, IDifficultyBeatmap ____selectedDifficultyBeatmap, LevelParamsPanel ____levelParamsPanel, StandardLevelDetailView __instance)
+        private static void Postfix(IBeatmapLevel ____level, IDifficultyBeatmap ____selectedDifficultyBeatmap, LevelParamsPanel ____levelParamsPanel, StandardLevelDetailView __instance)
         {
-            DataModel._actionButton = __instance.actionButton;
-
-            foreach (var bg in DataModel._actionButton.GetComponentsInChildren<ImageView>())
-            {
-                if (bg.name == "BG" && DataModel.defaultColor == new Color(0f, 0f, 0f, 0f))
-                {
-                    DataModel.defaultColor = bg.color;
-                }
-            }
+            var actionButton = DataModel._actionButton = __instance.actionButton;
 
             DataModel.difficultyBeatmap = ____selectedDifficultyBeatmap;
-            Enum.TryParse(DataModel.difficultyBeatmap.parentDifficultyBeatmapSet.beatmapCharacteristic.serializedName, out DataModel.characteristic);
+            DataModel.selectedLevelCategory = Resources.FindObjectsOfTypeAll<SelectLevelCategoryViewController>()
+                .FirstOrDefault()
+                ?.selectedLevelCategory
+                ?? SelectLevelCategoryViewController.LevelCategory.None;
 
-            SelectLevelCategoryViewController selectLevelCategoryViewController = Resources.FindObjectsOfTypeAll<SelectLevelCategoryViewController>().First();
+            if (actionButton?.gameObject == null)
+            {
+                Plugin.Log.Error("Failed to obtain actionButton.");
+                return;
+            }
+
+
+            if (DataModel.defaultColor == default)
+            {
+                DataModel.defaultColor = actionButton
+                        .GetComponentsInChildren<ImageView>()
+                        .SingleOrDefault(x => x.name == "BG")
+                        ?.color
+                        ?? default;
+            }
 
             if (PluginConfig.Instance.Enable)
             {
-                if (selectLevelCategoryViewController.selectedLevelCategory != SelectLevelCategoryViewController.LevelCategory.CustomSongs)
-                {
-                    if (DataModel.defaultColor != null && DataModel._actionButton != null)
-                    {
-                        foreach (var bg in DataModel._actionButton.GetComponentsInChildren<ImageView>())
-                        {
-                            if (bg.name == "BG")
-                            {
-                                if (bg.color == Color.red)
-                                {
-                                    bg.color = DataModel.defaultColor;
-                                    bg.SetField("_gradient", true);
-                                }
-                            }
-                        }
-                    }
-                }
-                else
-                {
-                    DataModel.RefreshButtonColor();
-                }
+                DataModel.RefreshButtonColor();
             }
         }
     }

--- a/ConfirmPlaylistDifficulty/PMEventHandler.cs
+++ b/ConfirmPlaylistDifficulty/PMEventHandler.cs
@@ -22,7 +22,7 @@ namespace ConfirmPlaylistDifficulty
             Instance = this;
         }
 
-        public void Start()
+        public void OnEnable()
         {
             PlaylistManager.Utilities.Events.playlistSongSelected += PlaylistSongSelected;
         }


### PR DESCRIPTION
## Summary
- Fixed #1 
- `DataModel._actionButton.gameObject` が `null` となることがあり、それにより `DataModel._actionButton.Get` が `NullReferenceException` を throw することが原因であると判明した。 (Appendix -> Error Log を参照)

## Changes
- `DataModel._actionButton.gameObject` の null check を追加し、`null` であった場合には背景色の処理を行わないよう修正
- 複数箇所に分散して記述されていたPlayボタン背景色の更新処理を一箇所に統合するようリファクタリング
  - ならびに、同処理の判定ロジックをリファクタリング

## Tests
- 同バグが修正されていることを確認
- 下記の状態で、Playボタンにデフォルトの背景色が適用されることを確認
    - プレイリストが選択されていない状態
    - プレイリストが選択されているが、プレイリストで難易度が選択されていない状態
    - プレイリストが選択されており、プレイリストで指定された難易度が選択されている状態
- 下記の状態で、Playボタンに警告背景色 ( `Color.Red` ) が適用されていることを確認
    - プレイリストが選択されており、プレイリストで指定された難易度 ( `charasteristic` 及び `difficulty` ) が選択されていない状態

## Appendix
### Error Log
```
[CRITICAL @ 17:37:14 | UnityEngine] NullReferenceException
[CRITICAL @ 17:37:14 | UnityEngine] UnityEngine.Component.GetComponentsInChildren[T] (System.Boolean includeInactive) (at <451019b49f1347529b43a32c5de769af>:0)
[CRITICAL @ 17:37:14 | UnityEngine] UnityEngine.Component.GetComponentsInChildren[T] () (at <451019b49f1347529b43a32c5de769af>:0)
[CRITICAL @ 17:37:14 | UnityEngine] ConfirmPlaylistDifficulty.DataModel.ChangeStartButtonColor (System.Boolean red) (at <5c77b75d870149d4b59adddee1c69143>:0)
[CRITICAL @ 17:37:14 | UnityEngine] ConfirmPlaylistDifficulty.DataModel.RefreshButtonColor () (at <5c77b75d870149d4b59adddee1c69143>:0)
[CRITICAL @ 17:37:14 | UnityEngine] ConfirmPlaylistDifficulty.PMEventHandler.PlaylistSongSelected (BeatSaberPlaylistsLib.Types.IPlaylistSong ps) (at <5c77b75d870149d4b59adddee1c69143>:0)
[CRITICAL @ 17:37:14 | UnityEngine] PlaylistManager.Utilities.Events.RaisePlaylistSongSelected (BeatSaberPlaylistsLib.Types.IPlaylistSong playlistSong) (at <7885b601797043658889851f732b6a04>:0)
[CRITICAL @ 17:37:14 | UnityEngine] PlaylistManager.PlaylistDataManager.LevelCollectionTableView_DidSelectLevelEvent (IPreviewBeatmapLevel previewBeatmapLevel) (at <7885b601797043658889851f732b6a04>:0)
[CRITICAL @ 17:37:14 | UnityEngine] PlaylistManager.HarmonyPatches.LevelCollectionTableView_HandleDidSelectRowEvent.Prefix (System.Int32 row, System.Boolean ____showLevelPackHeader) (at <7885b601797043658889851f732b6a04>:0)
[CRITICAL @ 17:37:14 | UnityEngine] (wrapper dynamic-method) LevelCollectionTableView.DMD<LevelCollectionTableView::HandleDidSelectRowEvent>(LevelCollectionTableView,HMUI.TableView,int)
[CRITICAL @ 17:37:14 | UnityEngine] HMUI.TableView.DidSelectCellWithIdx (System.Int32 idx) (at <a0917e0f3850459789b189954d81a352>:0)
[CRITICAL @ 17:37:14 | UnityEngine] HMUI.TableView.SelectCellWithIdx (System.Int32 idx, System.Boolean callbackTable) (at <a0917e0f3850459789b189954d81a352>:0)
[CRITICAL @ 17:37:14 | UnityEngine] (wrapper dynamic-method) LevelCollectionTableView.DMD<LevelCollectionTableView::SelectLevel>(LevelCollectionTableView,IPreviewBeatmapLevel)
[CRITICAL @ 17:37:14 | UnityEngine] LevelCollectionViewController.DidActivate (System.Boolean firstActivation, System.Boolean addedToHierarchy, System.Boolean screenSystemEnabling) (at <5efa267adbd744cfab93ae97ee85d4c7>:0)
[CRITICAL @ 17:37:14 | UnityEngine] HMUI.ViewController.__Activate (System.Boolean addedToHierarchy, System.Boolean screenSystemEnabling) (at <a0917e0f3850459789b189954d81a352>:0)
[CRITICAL @ 17:37:14 | UnityEngine] HMUI.ContainerViewController.SetChildViewControllers (HMUI.ViewController[] viewControllers) (at <a0917e0f3850459789b189954d81a352>:0)
[CRITICAL @ 17:37:14 | UnityEngine] (wrapper dynamic-method) LevelCollectionNavigationController.DMD<LevelCollectionNavigationController::DidActivate>(LevelCollectionNavigationController,bool,bool,bool)
[CRITICAL @ 17:37:14 | UnityEngine] HMUI.ViewController.__Activate (System.Boolean addedToHierarchy, System.Boolean screenSystemEnabling) (at <a0917e0f3850459789b189954d81a352>:0)
[CRITICAL @ 17:37:14 | UnityEngine] HMUI.ContainerViewController.__Activate (System.Boolean addedToHierarchy, System.Boolean screenSystemEnabling) (at <a0917e0f3850459789b189954d81a352>:0)
[CRITICAL @ 17:37:14 | UnityEngine] HMUI.ContainerViewController.SetChildViewControllers (HMUI.ViewController[] viewControllers) (at <a0917e0f3850459789b189954d81a352>:0)
[CRITICAL @ 17:37:14 | UnityEngine] LevelSelectionNavigationController.DidActivate (System.Boolean firstActivation, System.Boolean addedToHierarchy, System.Boolean screenSystemEnabling) (at <5efa267adbd744cfab93ae97ee85d4c7>:0)
[CRITICAL @ 17:37:14 | UnityEngine] HMUI.ViewController.__Activate (System.Boolean addedToHierarchy, System.Boolean screenSystemEnabling) (at <a0917e0f3850459789b189954d81a352>:0)
[CRITICAL @ 17:37:14 | UnityEngine] HMUI.ContainerViewController.__Activate (System.Boolean addedToHierarchy, System.Boolean screenSystemEnabling) (at <a0917e0f3850459789b189954d81a352>:0)
[CRITICAL @ 17:37:14 | UnityEngine] HMUI.ViewController+<PresentViewControllerCoroutine>d__58.MoveNext () (at <a0917e0f3850459789b189954d81a352>:0)
[CRITICAL @ 17:37:14 | UnityEngine] UnityEngine.SetupCoroutine.InvokeMoveNext (System.Collections.IEnumerator enumerator, System.IntPtr returnValueAddress) (at <451019b49f1347529b43a32c5de769af>:0)
[CRITICAL @ 17:37:14 | UnityEngine] UnityEngine.MonoBehaviour:StartCoroutine(IEnumerator)
[CRITICAL @ 17:37:14 | UnityEngine] HMUI.ViewController:__PresentViewController(ViewController, Action, AnimationDirection, Boolean)
[CRITICAL @ 17:37:14 | UnityEngine] HMUI.FlowCoordinator:PresentViewController(ViewController, Action, AnimationDirection, Boolean)
[CRITICAL @ 17:37:14 | UnityEngine] HMUI.FlowCoordinator:PresentFlowCoordinator(FlowCoordinator, Action, AnimationDirection, Boolean, Boolean)
[CRITICAL @ 17:37:14 | UnityEngine] MainFlowCoordinator:PresentFlowCoordinatorOrAskForTutorial(FlowCoordinator)
[CRITICAL @ 17:37:14 | UnityEngine] MainFlowCoordinator:HandleMainMenuViewControllerDidFinish(MainMenuViewController, MenuButton)
[CRITICAL @ 17:37:14 | UnityEngine] MainMenuViewController:HandleMenuButton(MenuButton)
[CRITICAL @ 17:37:14 | UnityEngine] MainMenuViewController:<DidActivate>b__20_0()
[CRITICAL @ 17:37:14 | UnityEngine] UnityEngine.EventSystems.ExecuteEvents:Execute(GameObject, BaseEventData, EventFunction`1)
[CRITICAL @ 17:37:14 | UnityEngine] VRUIControls.VRInputModule:ProcessMousePress(MouseButtonEventData)
[CRITICAL @ 17:37:14 | UnityEngine] VRUIControls.VRInputModule:Process()
[CRITICAL @ 17:37:14 | UnityEngine] UnityEngine.EventSystems.EventSystem:Update()
```